### PR TITLE
Avoid unnecessarily overwriting Makefile variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 ALL=nq fq tq
 
-CFLAGS=-g -Wall -O2
+CC?=cc
+CFLAGS?=-g -Wall -O2
 
-DESTDIR=
-PREFIX=/usr/local
-BINDIR=$(PREFIX)/bin
-MANDIR=$(PREFIX)/share/man
+DESTDIR?=
+PREFIX?=/usr/local
+BINDIR?=$(PREFIX)/bin
+MANDIR?=$(PREFIX)/share/man
 
 all: $(ALL)
 


### PR DESCRIPTION
The Makefile in its original form sets certain variables, like PREFIX, in a way which will override the user's (or build environment's) existing settings. Switching the "=" to the "?=" symbol allows the host environment to set things like the compiler and PREFIX automatically, without needing to patch the Makefile.

This will make porting to other platforms like FreeBSD easier.